### PR TITLE
Cosmetic fix - minify pack name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
-## v0.1.0
+## v0.1.1
+* Pack name fix
 
+## v0.1.0
 * Initial release

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,11 +1,12 @@
 ---
 ref: openai
-name: OpenAI Query Pack
+name: openai
 description: Pack to query OpenAI API
 keywords:
   - openai
   - ai
-version: 0.1.0
+  - chatgpt
+version: 0.1.1
 python_versions:
   - "3"
 author: David Larsen


### PR DESCRIPTION
Cosmetic fix to minify the pack name to follow the same consistent one-word format with other packs.

<img width="1405" alt="image" src="https://github.com/StackStorm-Exchange/stackstorm-openai/assets/1533818/06a24692-9ba8-4a85-84ff-e2e809063357">
